### PR TITLE
feat: support manual `channel.pipe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each of these JSContext environments exhibits distinct methods of communicating 
     - [.implementChannel()](#implementchannel)
     - [.postMessage()](#postmessage)
     - [.onMessage()](#onmessage)
+    - [.pipe()](#pipe)
   - [UnportChannelMessage](#unportchannelmessage)
 - [🤝 Contributing](#-contributing)
 - [🤝 Credits](#-credits)
@@ -138,6 +139,7 @@ childPort.implementChannel({
   },
 });
 
+// 3. You get a complete typed Port with a unified interface 🤩
 childPort.onMessage('syn', payload => {
   console.log('[child] [syn]', payload.pid);
   childPort.postMessage('ack', { pid: 'child' });
@@ -258,6 +260,27 @@ parentPort.onMessage('ack', payload => {
   });
 });
 ```
+
+#### .pipe()
+
+- Type: `(message: UnportChannelMessage) => void`
+
+The `pipe` method is used to manually handle incoming messages. It's often used in Server with `one-to-many` connections, e.g. Web Socket.
+
+Example:
+
+```ts
+const channel = port.implementChannel({
+  send: (message) => {
+    // send message to the other end of the channel
+  },
+});
+
+// when a message is received
+channel.pipe(message);
+```
+
+See our [Web Socket](./examples/web-socket/) example to check more details.
 
 ### UnportChannelMessage
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,7 +9,7 @@ export type Definition = {
     body: {
       name: string;
       path: string;
-    }
+    };
   };
   child2parent: {
     ack: {
@@ -28,14 +28,41 @@ describe('Unport', () => {
   beforeEach(() => {
     mockChannel = {
       send: vi.fn(),
-      // we add an extra "mockReceiveMessage" method here so that we can test the "onMessage" handler
-      accept: vi.fn().mockImplementation(function (pipe) { this.mockReceiveMessage = pipe; }),
+      accept: vi.fn(),
     };
 
-    unPort = new Unport<Definition, 'parent'>().implementChannel(mockChannel);
+    unPort = new Unport<Definition, 'parent'>();
+  });
+
+  test('should implement channel correctly when provided channel as object', () => {
+    unPort.implementChannel(mockChannel);
+    expect(mockChannel.accept).toHaveBeenCalledOnce();
+    expect(unPort.channel).toBe(mockChannel);
+  });
+
+  test('should implement channel correctly when provided channel as function returning object', () => {
+    const mockChannelFn = () => mockChannel;
+    unPort.implementChannel(mockChannelFn);
+    expect(unPort.channel).toBe(mockChannel);
+  });
+
+  test('should throw error when provided invalid channel object', () => {
+    const invalidChannel = {}; // Does not contain required 'send' method
+    // @ts-expect-error we mocked error here
+    expect(() => unPort.implementChannel(invalidChannel)).toThrowError(
+      '[1] invalid channel implementation',
+    );
+  });
+
+  test('should throw error when provided invalid channel function', () => {
+    const invalidChannelFn = () => ({} as UnportChannel); // Does not contain required 'send' method
+    expect(() => unPort.implementChannel(invalidChannelFn)).toThrowError(
+      '[1] invalid channel implementation',
+    );
   });
 
   test('should correctly call channel send method', () => {
+    unPort.implementChannel(mockChannel);
     unPort.postMessage('syn', { pid: '1' });
     expect(mockChannel.send).toHaveBeenCalledWith({
       t: 'syn',
@@ -45,36 +72,39 @@ describe('Unport', () => {
   });
 
   test('should correctly call registered message handler', () => {
+    const channel = unPort.implementChannel(mockChannel);
     const messageHandler = vi.fn();
 
     unPort.onMessage('ack', messageHandler);
-    // @ts-expect-error we mocked callback here
-    mockChannel.mockReceiveMessage({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
+    channel.pipe({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
 
     expect(messageHandler).toHaveBeenCalledWith({ pid: 'child' });
   });
 
   test('should not call message handler when _$ is not "un"', () => {
+    const channel = unPort.implementChannel(mockChannel);
     const messageHandler = vi.fn();
 
     unPort.onMessage('ack', messageHandler);
-    // @ts-expect-error we mock error here
-    mockChannel.mockReceiveMessage({ t: 'ack', p: { pid: 'child' }, _$: 'other' });
+    // @ts-expect-error we mocked error here
+    channel.pipe({ t: 'ack', p: { pid: 'child' }, _$: 'other' });
 
     expect(messageHandler).not.toHaveBeenCalledWith();
   });
 
   test('should ignore unknown messages', () => {
+    const channel = unPort.implementChannel(mockChannel);
     const messageHandler = vi.fn();
 
     unPort.onMessage('ack', messageHandler);
-    // @ts-expect-error we mocked callback here
-    mockChannel.mockReceiveMessage({ t: 'ack', p: { pid: 'child' }, _$: 'other' });
+    // @ts-expect-error we mocked error here
+    channel.pipe('unknown');
 
     expect(messageHandler).not.toHaveBeenCalledWith();
   });
 
   test('should correctly handle multiple message handlers', () => {
+    const channel = unPort.implementChannel(mockChannel);
     const messageHandler1 = vi.fn();
     const messageHandler2 = vi.fn();
     const messageHandler3 = vi.fn();
@@ -82,8 +112,7 @@ describe('Unport', () => {
     unPort.onMessage('ack', messageHandler1);
     unPort.onMessage('ack', messageHandler2);
     unPort.onMessage('ack', messageHandler3);
-    // @ts-expect-error we mocked callback here
-    mockChannel.mockReceiveMessage({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
+    channel.pipe({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
 
     expect(messageHandler1).toHaveBeenCalledWith({ pid: 'child' });
     expect(messageHandler2).toHaveBeenCalledWith({ pid: 'child' });
@@ -91,29 +120,31 @@ describe('Unport', () => {
   });
 
   test('should handle port destruction correctly - postMessage', () => {
+    const channel = unPort.implementChannel(mockChannel);
     unPort.postMessage('syn', { pid: '1' });
     expect(mockChannel.send).toHaveBeenCalledTimes(1);
 
     unPort.destroy();
 
     // When the port has been destroyed, it should no longer accept messages
-    expect(() => unPort.postMessage('syn', { pid: '1' })).toThrow();
+    expect(() => unPort.postMessage('syn', { pid: '1' })).toThrowError(
+      '[2] Port is not implemented or has been destroyed',
+    );
     expect(mockChannel.send).toHaveBeenCalledTimes(1);
   });
 
   test('should handle port destruction correctly - onMessage', () => {
+    const channel = unPort.implementChannel(mockChannel);
     const messageHandler = vi.fn();
 
     // Handlers registered after destroy should not get called
     unPort.onMessage('ack', messageHandler);
-    // @ts-expect-error we mocked callback here
-    mockChannel.mockReceiveMessage({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
+    channel.pipe({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
     expect(messageHandler).toBeCalledTimes(1);
 
     unPort.destroy();
 
-    // @ts-expect-error we mocked callback here
-    mockChannel.mockReceiveMessage({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
+    channel.send({ t: 'ack', p: { pid: 'child' }, _$: 'un' });
     expect(messageHandler).toBeCalledTimes(1);
   });
 });

--- a/examples/child-process/child.ts
+++ b/examples/child-process/child.ts
@@ -21,7 +21,6 @@ childPort.onMessage('syn', payload => {
   console.log('[child] [syn]', payload.pid);
   childPort.postMessage('ack', { pid: 'child' });
 });
-
 childPort.onMessage('body', payload => {
   console.log('[child] [body]', JSON.stringify(payload));
 });

--- a/examples/web-socket/client.ts
+++ b/examples/web-socket/client.ts
@@ -1,0 +1,29 @@
+import io from 'socket.io-client';
+import { Unport } from '../../src';
+import { ClientPort } from './port';
+
+// 1. Initialize a port
+const clientPort: ClientPort = new Unport();
+
+// 2. Implement a UnportChannel based on underlying IPC capabilities
+const socket = io('http://localhost:10101/');
+socket.on('connect', () => {
+  clientPort.implementChannel(() => ({
+    send(message) {
+      socket.emit('message', message);
+    },
+    accept(pipe) {
+      socket.on('message', pipe);
+    },
+  }));
+});
+
+// 3. You get a complete typed Port with a unified interface 🤩
+clientPort.postMessage('syn', { pid: 'parent' });
+clientPort.onMessage('ack', payload => {
+  console.log('[parent] [ack]', payload.pid);
+  clientPort.postMessage('body', {
+    name: 'index',
+    path: ' /',
+  });
+});

--- a/examples/web-socket/index.html
+++ b/examples/web-socket/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Socket-IO client</title>
+    <script src="https://cdn.socket.io/4.4.0/socket.io.min.js"></script>
+  </head>
+  <body>
+    <script type="text/javascript">
+      // FIXME: using CDN link
+      class Unport {
+        constructor() {
+          this.handlers = {};
+          this.postMessage = (t, p) => {
+            if (!this.channel) {
+              throw new Error("Port is not implemented or has been destroyed");
+            }
+            this.channel.send({ t, p, _$: "un" });
+          };
+          this.onMessage = (t, handler) => {
+            if (!this.handlers[t]) {
+              this.handlers[t] = [];
+            }
+            this.handlers[t].push(handler);
+          };
+        }
+        implementChannel(channel) {
+          this.channel = typeof channel === "function" ? channel() : channel;
+          this.channel.accept((message) => {
+            if (typeof message === "object" && message._$ === "un") {
+              const { t, p } = message;
+              const handler = this.handlers[t];
+              if (handler) {
+                handler.forEach((fn) => fn(p));
+              }
+            }
+          });
+          return this;
+        }
+        destroy() {
+          var _a;
+          this.handlers = {};
+          ((_a = this.channel) === null || _a === void 0
+            ? void 0
+            : _a.destroy) && this.channel.destroy();
+          delete this.channel;
+        }
+      }
+
+      // 1. Initialize a port
+      const clientPort = new Unport();
+      const socket = io("http://localhost:10101/");
+
+      // 2. Implement a UnportChannel based on underlying Socket.IO
+      socket.on("connect", () => {
+        clientPort.implementChannel(() => ({
+          send: function (message) {
+            socket.emit("message", message);
+          },
+          accept: function (pipe) {
+            socket.on("message", pipe);
+          },
+        }));
+
+        // 3. You get a complete typed Port with a unified interface 🤩
+        clientPort.postMessage("syn", { pid: "parent" });
+        clientPort.onMessage("ack", (payload) => {
+          console.log("[parent] [ack]", payload.pid);
+          clientPort.postMessage("body", {
+            name: "index",
+            path: " /",
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/examples/web-socket/port.ts
+++ b/examples/web-socket/port.ts
@@ -1,0 +1,21 @@
+import { Unport } from '../../src';
+
+export type Definition = {
+  server2client: {
+    ack: {
+      pid: string;
+    };
+  };
+  client2server: {
+    syn: {
+      pid: string;
+    };
+    body: {
+      name: string;
+      path: string;
+    }
+  };
+};
+
+export type ClientPort = Unport<Definition, 'client'>;
+export type ServerPort = Unport<Definition, 'server'>;

--- a/examples/web-socket/server-legcy.ts
+++ b/examples/web-socket/server-legcy.ts
@@ -1,0 +1,56 @@
+/**
+ * This file using a old implementation for `one-to-many` scenario,
+ * which could be refactored by `.pipe()`,
+ *
+ * @see https://github.com/web-infra-dev/unport/pull/2
+ */
+import { createServer } from 'http';
+import { Server as SocketServer, Socket } from 'socket.io';
+import { ServerPort } from './port';
+import { Unport } from '../../src';
+
+// 1. Initialize a port map
+const socketPorts: Map<string, ServerPort> = new Map();
+
+// 2. Implement a UnportChannel based on underlying IPC capabilities
+const server = createServer();
+const io = new SocketServer(server, {
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+});
+
+io.on('connection', (socket: Socket) => {
+  // One connection, one port instance
+  const socketPort: ServerPort = new Unport();
+  socketPort.implementChannel({
+    send: message => {
+      socket.emit('message', message);
+    },
+    accept(pipe) {
+      socket.on('message', message => {
+        pipe(message);
+      });
+    },
+  });
+
+  socketPorts.set(socket.id, socketPort);
+
+  socket.on('disconnect', () => {
+    socketPorts.delete(socket.id);
+  });
+});
+
+server.listen(10101);
+
+// You'll get many ports so that you need to retrieve it before using it.
+const serverPort = socketPorts.get('<id>' /* id */);
+
+serverPort.onMessage('syn', payload => {
+  console.log('[child] [syn]', payload.pid);
+  serverPort.postMessage('ack', { pid: 'child' });
+});
+serverPort.onMessage('body', payload => {
+  console.log('[child] [body]', JSON.stringify(payload));
+});

--- a/examples/web-socket/server.ts
+++ b/examples/web-socket/server.ts
@@ -1,0 +1,43 @@
+import { createServer } from 'http';
+import { Server as SocketServer, Socket } from 'socket.io';
+import { ServerPort } from './port';
+import { Unport } from '../../src';
+
+// 1. Initialize a port
+const serverPort: ServerPort = new Unport();
+
+// 2. Implement a UnportChannel based on underlying IPC capabilities
+const server = createServer();
+const io = new SocketServer(server, {
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+});
+const sockets: Record<string, Socket> = {};
+const channel = serverPort.implementChannel({
+  send: message => {
+    Object.values(sockets).forEach(socket => {
+      socket.emit('message', message);
+    });
+  },
+});
+io.on('connection', (socket: Socket) => {
+  sockets[socket.id] = socket;
+  socket.on('disconnect', () => {
+    delete sockets[socket.id];
+  });
+  socket.on('message', message => channel.pipe(message));
+});
+
+server.listen(10101);
+
+// 3. You get a complete typed Port with a unified interface 🤩
+serverPort.onMessage('syn', payload => {
+  console.log('[child] [syn]', payload.pid);
+  serverPort.postMessage('ack', { pid: 'child' });
+});
+serverPort.onMessage('body', payload => {
+  console.log('[child] [body]', JSON.stringify(payload));
+});
+

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "quick-publish": "0.6.0",
     "tsx": "^4.1.2",
     "typescript": "4.7.4",
-    "vitest": "^0.34.6"
+    "vitest": "^0.34.6",
+    "socket.io": "^4.7.2",
+    "socket.io-client": "^4.5.1"
   },
   "files": [
     "bin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ devDependencies:
   quick-publish:
     specifier: 0.6.0
     version: 0.6.0
+  socket.io:
+    specifier: ^4.7.2
+    version: 4.7.2
+  socket.io-client:
+    specifier: ^4.5.1
+    version: 4.7.2
   tsx:
     specifier: ^4.1.2
     version: 4.1.2
@@ -685,6 +691,10 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
+  /@socket.io/component-emitter@3.1.0:
+    resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
+    dev: true
+
   /@types/chai-subset@1.3.5:
     resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
     dependencies:
@@ -693,6 +703,16 @@ packages:
 
   /@types/chai@4.3.10:
     resolution: {integrity: sha512-of+ICnbqjmFCiixUnqRulbylyXQrPqIGf/B3Jax1wIF3DvSheysQxAWvqHhZiW3IQrycvokcLcFQlveGp+vyNg==}
+    dev: true
+
+  /@types/cookie@0.4.1:
+    resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
+    dev: true
+
+  /@types/cors@2.8.15:
+    resolution: {integrity: sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==}
+    dependencies:
+      '@types/node': 18.7.6
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
@@ -919,6 +939,14 @@ packages:
       through: 2.3.8
     dev: true
 
+  /accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@7.4.1):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1079,6 +1107,11 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
     dev: true
 
   /brace-expansion@1.1.11:
@@ -1393,8 +1426,21 @@ packages:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
 
+  /cookie@0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: true
+
+  /cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
     dev: true
 
   /cross-spawn@6.0.5:
@@ -1527,6 +1573,45 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+    dev: true
+
+  /engine.io-client@6.5.3:
+    resolution: {integrity: sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+      engine.io-parser: 5.2.1
+      ws: 8.11.0
+      xmlhttprequest-ssl: 2.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /engine.io-parser@5.2.1:
+    resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
+    engines: {node: '>=10.0.0'}
+    dev: true
+
+  /engine.io@6.5.3:
+    resolution: {integrity: sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      '@types/cookie': 0.4.1
+      '@types/cors': 2.8.15
+      '@types/node': 18.7.6
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.4.2
+      cors: 2.8.5
+      debug: 4.3.4
+      engine.io-parser: 5.2.1
+      ws: 8.11.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /enhanced-resolve@5.12.0:
@@ -2897,6 +2982,18 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2964,6 +3061,11 @@ packages:
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
+  /negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
     dev: true
 
   /neo-async@2.6.2:
@@ -3641,6 +3743,56 @@ packages:
       is-fullwidth-code-point: 3.0.0
     dev: true
 
+  /socket.io-adapter@2.5.2:
+    resolution: {integrity: sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==}
+    dependencies:
+      ws: 8.11.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /socket.io-client@4.7.2:
+    resolution: {integrity: sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+      engine.io-client: 6.5.3
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /socket.io-parser@4.2.4:
+    resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /socket.io@4.7.2:
+    resolution: {integrity: sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.3.4
+      engine.io: 6.5.3
+      socket.io-adapter: 2.5.2
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
@@ -4076,6 +4228,11 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
   /vite-node@0.34.6(@types/node@18.7.6):
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
     engines: {node: '>=v14.18.0'}
@@ -4265,6 +4422,24 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /ws@8.11.0:
+    resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /xmlhttprequest-ssl@2.0.0:
+    resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /xtend@4.0.2:


### PR DESCRIPTION
# Motivation

Previously, for `one-to-many` IPC scenarios (e.g. Web Socket), we had to create multiple Unport instances

```ts
import { createServer } from 'http';
import { Server as SocketServer, Socket } from 'socket.io';
import { ServerPort } from './port';
import { Unport } from '../../src';

// 1. Initialize a port map
const socketPorts: Map<string, ServerPort> = new Map();

// 2. Implement a UnportChannel based on underlying IPC capabilities
const server = createServer();
const io = new SocketServer(server, {
  cors: {
    origin: '*',
    methods: ['GET', 'POST'],
  },
});

io.on('connection', (socket: Socket) => {
  // One connection, one port instance
  const socketPort: ServerPort = new Unport();
  socketPort.implementChannel({
    send: message => {
      socket.emit('message', message);
    },
    accept(pipe) {
      socket.on('message', message => {
        pipe(message);
      });
    },
  });

  socketPorts.set(socket.id, socketPort);

  socket.on('disconnect', () => {
    socketPorts.delete(socket.id);
  });
});

server.listen(10101);

// You'll get many ports so that you need to retrieve it before using it.
const serverPort = socketPorts.get('<id>' /* id */);

serverPort.onMessage('syn', payload => {
  console.log('[child] [syn]', payload.pid);
  serverPort.postMessage('ack', { pid: 'child' });
});
serverPort.onMessage('body', payload => {
  console.log('[child] [body]', JSON.stringify(payload));
});
```

With `pipe` method, you'll only need one instance:

```ts
import { createServer } from 'http';
import { Server as SocketServer, Socket } from 'socket.io';
import { ServerPort } from './port';
import { Unport } from '../../src';

// 1. Initialize a port
const serverPort: ServerPort = new Unport();

// 2. Implement a UnportChannel based on underlying IPC capabilities
const server = createServer();
const io = new SocketServer(server, {
  cors: {
    origin: '*',
    methods: ['GET', 'POST'],
  },
});
const sockets: Record<string, Socket> = {};
const channel = serverPort.implementChannel({
  send: message => {
    Object.values(sockets).forEach(socket => {
      socket.emit('message', message);
    });
  },
});
io.on('connection', (socket: Socket) => {
  sockets[socket.id] = socket;
  socket.on('disconnect', () => {
    delete sockets[socket.id];
  });
  socket.on('message', message => channel.pipe(message));
});

server.listen(10101);

// 3. You get a complete typed Port with a unified interface 🤩
serverPort.onMessage('syn', payload => {
  console.log('[child] [syn]', payload.pid);
  serverPort.postMessage('ack', { pid: 'child' });
});
serverPort.onMessage('body', payload => {
  console.log('[child] [body]', JSON.stringify(payload));
});
```